### PR TITLE
Add manifest.createtask support

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ for more information on how to use them.
 - file.download
 - macro.creatememe
 - maniphest.query
+- maniphest.createtask
 - paste.create
 - paste.query
 - phid.lookup

--- a/maniphest.go
+++ b/maniphest.go
@@ -1,6 +1,7 @@
 package gonduit
 
 import (
+	"github.com/etcinit/gonduit/entities"
 	"github.com/etcinit/gonduit/requests"
 	"github.com/etcinit/gonduit/responses"
 )
@@ -10,6 +11,17 @@ func (c *Conn) ManiphestQuery(req requests.ManiphestQueryRequest) (*responses.Ma
 	var res responses.ManiphestQueryResponse
 
 	if err := c.Call("maniphest.query", &req, &res); err != nil {
+		return nil, err
+	}
+
+	return &res, nil
+}
+
+// ManiphestCreateTask performs a call to maniphest.createtask.
+func (c *Conn) ManiphestCreateTask(req requests.ManiphestCreateTaskRequest) (*entities.ManiphestTask, error) {
+	var res entities.ManiphestTask
+
+	if err := c.Call("maniphest.createtask", &req, &res); err != nil {
 		return nil, err
 	}
 

--- a/requests/maniphest_createtask.go
+++ b/requests/maniphest_createtask.go
@@ -1,0 +1,14 @@
+package requests
+
+// ManiphestCreateTaskRequest represents a request to maniphest.createtask.
+type ManiphestCreateTaskRequest struct {
+	Title        string                        `json:"title"`
+	Description  string                        `json:"description"`
+	OwnerPHID    string                        `json:"ownerPHID"`
+	ViewPolicy   string                        `json:"viewPolicy"`
+	EditPolicy   string                        `json:"editPolicy"`
+	CCPHIDs      []string                      `json:"ccPHIDs"`
+	Priority     int                           `json:"priority"`
+	ProjectPHIDs []string                      `json:"projectPHIDs"`
+	Request
+}


### PR DESCRIPTION
Adds support for the `manifest.createtask` method via the `ManiphestCreateTask` function and `requests.ManiphestCreateTaskRequest`
