### PR TITLE
DifferentialRevision.Reviewers []string to map[string]string

### DIFF
--- a/entities/differential.go
+++ b/entities/differential.go
@@ -20,7 +20,7 @@ type DifferentialRevision struct {
 	ActiveDiffPHID string              `json:"activeDiffPHID"`
 	Diffs          []string            `json:"diffs"`
 	Commits        []string            `json:"commits"`
-	Reviewers      []string            `json:"reviewers"`
+	Reviewers      map[string]string   `json:"reviewers"`
 	CCs            []string            `json:"ccs"`
 	Hashes         [][]string          `json:"hashes"`
 	Auxiliary      map[string][]string `json:"auxiliary"`


### PR DESCRIPTION
Changing DifferentialRevision.Reviewers from a `[]string` to a `map[string]string` to account for an apparently recent change in the Conduit API.

Will also submit a PR for a related change to Phabulous.