### PR TITLE
Fix repository.query request

### DIFF
--- a/requests/repository_query.go
+++ b/requests/repository_query.go
@@ -8,7 +8,7 @@ type RepositoryQueryRequest struct {
 	VCSTypes   []string `json:"vcsTypes"`
 	RemoteURIs []string `json:"remoteURIs"`
 	UUIDs      []string `json:"uuids"`
-	Order      string   `json:"order"`
+	Order      *string  `json:"order"`
 	Before     string   `json:"before"`
 	After      string   `json:"after"`
 	Limit      uint64   `json:"limit"`


### PR DESCRIPTION
Order must be nil if it isn't provided

Request example:
`{"ids":null,"phids":null,"callsigns":["SOME"],"vcsTypes":null,"remoteURIs":null,"uuids":null,"order":"","before":"","after":"","limit":0,"__conduit__":{"token":"***"}}`

Response:
`{"error":"ERR-CONDUIT-CORE","errorMessage":"ERR-CONDUIT-CORE: Query \"PhabricatorRepositoryQuery\" does not support a builtin order \"\". Supported orders are: committed, name, callsign, size, newest, created, oldest.","response":null}`