### PR TITLE
Make all maniphest.createtask options (other than title and description) optional

### DIFF
--- a/requests/maniphest_createtask.go
+++ b/requests/maniphest_createtask.go
@@ -2,13 +2,13 @@ package requests
 
 // ManiphestCreateTaskRequest represents a request to maniphest.createtask.
 type ManiphestCreateTaskRequest struct {
-	Title        string                        `json:"title"`
-	Description  string                        `json:"description"`
-	OwnerPHID    string                        `json:"ownerPHID"`
-	ViewPolicy   string                        `json:"viewPolicy"`
-	EditPolicy   string                        `json:"editPolicy"`
-	CCPHIDs      []string                      `json:"ccPHIDs"`
-	Priority     int                           `json:"priority"`
-	ProjectPHIDs []string                      `json:"projectPHIDs"`
+	Title        string   `json:"title"`
+	Description  string   `json:"description"`
+	OwnerPHID    string   `json:"ownerPHID,omitempty"`
+	ViewPolicy   string   `json:"viewPolicy,omitempty"`
+	EditPolicy   string   `json:"editPolicy,omitempty"`
+	CCPHIDs      []string `json:"ccPHIDs,omitempty"`
+	Priority     int      `json:"priority,omitempty"`
+	ProjectPHIDs []string `json:"projectPHIDs,omitempty"`
 	Request
 }


### PR DESCRIPTION
If these are empty, don't send them in the request. ViewPolicy/EditPolicy of empty strings can be
illegal. Not setting them at all will cause the default policy to be applied.