### PR TITLE
Adding (partial) support for differential.querydiffs, and a timeout client option

### DIFF
--- a/core/http.go
+++ b/core/http.go
@@ -3,6 +3,7 @@ package core
 import (
 	"crypto/tls"
 	"net/http"
+	"time"
 )
 
 // ClientOptions are options that can be set on the HTTP client.
@@ -14,11 +15,13 @@ type ClientOptions struct {
 	SessionKey string
 
 	InsecureSkipVerify bool
+	Timeout            time.Duration
 }
 
 // makeHttpClient creates a new HTTP client for making API requests.
 func makeHTTPClient(options *ClientOptions) *http.Client {
 	return &http.Client{
+		Timeout: options.Timeout,
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{
 				InsecureSkipVerify: options.InsecureSkipVerify,

--- a/differential.go
+++ b/differential.go
@@ -17,3 +17,16 @@ func (c *Conn) DifferentialQuery(
 
 	return &res, nil
 }
+
+// DifferentialQuery performs a call to differential.querydiffs.
+func (c *Conn) DifferentialQueryDiffs(
+	req requests.DifferentialQueryDiffsRequest,
+) (*responses.DifferentialQueryDiffsResponse, error) {
+	var res responses.DifferentialQueryDiffsResponse
+
+	if err := c.Call("differential.querydiffs", &req, &res); err != nil {
+		return nil, err
+	}
+
+	return &res, nil
+}

--- a/entities/differential.go
+++ b/entities/differential.go
@@ -26,3 +26,34 @@ type DifferentialRevision struct {
 	Auxiliary      map[string][]string `json:"auxiliary"`
 	RepositoryPHID string              `json:"repositoryPHID"`
 }
+
+// DifferentialDiff represents a specific diff within a Differential revision.
+// A new diff is created every time you update a differential revision (that's
+// what arc diff does duh).
+//
+// NOTE: Two fields are missing from this struct:
+//
+// - Changes (changes) is a list of a fairly complex data-structure with all
+//   hunks contained in this diff along with some dynamically typed metadata;
+// - Properties (properties) is another dynamically typed field which will be
+//   an empty list on a closed diff (as far as I can tell) or a fairly complex
+//   data-structure containing more metadata about the diff (info about the
+//   local commits and about arc's interaction with the staging area if you
+//   repository has one set up).
+type DifferentialDiff struct {
+	ID                        string             `json:"id"`
+	RevisionID                string             `json:"revisionID"`
+	DateCreated               util.UnixTimestamp `json:"dateCreated"`
+	DateModified              util.UnixTimestamp `json:"dateModified"`
+	SourceControlBaseRevision string             `json:"sourceControlBaseRevision"`
+	SourceControlPath         string             `json:"sourceControlPath"`
+	SourceControlSystem       string             `json:"sourceControlSystem"`
+	Branch                    string             `json:"branch"`
+	Bookmark                  string             `json:"bookmark"`
+	CreationMethod            string             `json:"creationMethod"`
+	Description               string             `json:"description"`
+	UnitStatus                string             `json:"unitStatus"`
+	LintStatus                string             `json:"lintStatus"`
+	AuthorName                string             `json:"authorName"`
+	AuthorEmail               string             `json:"authorEmail"`
+}

--- a/requests/differential_querydiffs.go
+++ b/requests/differential_querydiffs.go
@@ -1,0 +1,9 @@
+package requests
+
+// DifferentialQueryRequest represents a request
+// to the differential.querydiffs call.
+type DifferentialQueryDiffsRequest struct {
+	IDs         []uint64 `json:"ids"`
+	RevisionIDs []uint64 `json:"revisionIDs"`
+	Request
+}

--- a/responses/differential_querydiffs.go
+++ b/responses/differential_querydiffs.go
@@ -1,0 +1,6 @@
+package responses
+
+import "github.com/etcinit/gonduit/entities"
+
+// DifferentialQueryDiffsResponse is the response of calling differential.querydiffs.
+type DifferentialQueryDiffsResponse []*entities.DifferentialDiff


### PR DESCRIPTION
Hello,

cc: @Pawka

Thank you for maintaining that library (and @jpoehls for the original implementation), I found it very useful while implementing a project at my company!

I had to make those two changes though:

1. Add a timeout option so that you can fail fast on the conduit calls;
1. Add request/response structs for `differential.querydiffs`, note that the structure is missing a couple fields that are very tricky to un-marshal, hope that's fine for now.

In the area of 1., another option I expect a need for is the ability to pass custom HTTP headers. I think it's reasonable at this time to add a new `Header` field (of type [`net.http.Header`](https://golang.org/pkg/net/http/#Header)), but I'm wondering how well that approach of passing HTTP options via `ClientOptions` is going to scale, so I'm wondering if other people have an opinion here.

Let me know, if you have any question.

Best